### PR TITLE
added dvorak touch keyboard layout

### DIFF
--- a/data/layouts/touch/Makefile.am
+++ b/data/layouts/touch/Makefile.am
@@ -4,11 +4,14 @@ touchlayouts_in_files =\
     de.xml.in \
     fr.xml.in \
     il.xml.in \
-    us.xml.in
+    us.xml.in \
+    us_dvorak.xml.in
+
 touchlayouts_DATA = $(touchlayouts_in_files:.xml.in=.xml)
 
 common_files = \
 	common/azerty.xml \
+	common/dvorak.xml \
 	common/qwerty.xml \
 	common/qwertz.xml \
 	common/symbols.xml
@@ -17,6 +20,7 @@ ara.xml: $(common_files)
 de.xml: $(common_files)
 il.xml: $(common_files)
 us.xml: $(common_files)
+us_dvorak.xml: $(common_files)
 
 SUFFIXES = .xml.in .xml
 

--- a/data/layouts/touch/common/dvorak.xml
+++ b/data/layouts/touch/common/dvorak.xml
@@ -1,0 +1,194 @@
+<?xml version="1.0" ?>
+<external>
+  <level mode="default" name="level1">
+    <row align="right">
+      <key name="apostrophe"/>
+      <key name="comma"/>
+      <key name="period"/>
+      <key name="p"/>
+      <key name="y"/>
+      <key name="f"/>
+      <key name="g"/>
+      <key name="c">
+        <key name="c"/>
+        <key name="ccedilla"/>
+      </key>
+      <key name="r"/>
+      <key name="l"/>
+      <key name="slash" width="0.6"/>
+      <key name="equal" width="0.6"/>
+      <key name="backslash" width="0.6"/>
+      <key name="BackSpace" repeatable="yes"/>
+    </row>
+    <row align="right">
+      <key name="a">
+        <key name="a"/>
+        <key name="agrave"/>
+        <key name="aacute"/>
+        <key name="acircumflex"/>
+        <key name="adiaeresis"/>
+        <key name="aring"/>
+        <key name="atilde"/>
+        <key name="ae"/>
+        <key name="amacron"/>
+      </key>
+      <key name="o">
+        <key name="o"/>
+        <key name="ograve"/>
+        <key name="oacute"/>
+        <key name="ocircumflex"/>
+        <key name="odiaeresis"/>
+        <key name="omacron"/>
+      </key>
+      <key name="e">
+        <key name="e"/>
+        <key name="egrave"/>
+        <key name="eacute"/>
+        <key name="ecircumflex"/>
+        <key name="ediaeresis"/>
+        <key name="emacron"/>
+      </key>
+      <key name="u">
+        <key name="u"/>
+        <key name="ugrave"/>
+        <key name="uacute"/>
+        <key name="ucircumflex"/>
+        <key name="udiaeresis"/>
+        <key name="umacron"/>
+      </key>
+      <key name="i">
+        <key name="i"/>
+        <key name="igrave"/>
+        <key name="iacute"/>
+        <key name="icircumflex"/>
+        <key name="idiaeresis"/>
+        <key name="imacron"/>
+      </key>
+      <key name="d"/>
+      <key name="h"/>
+      <key name="t"/>
+      <key name="n"/>
+      <key name="s"/>
+      <key name="minus"/>
+      <key name="Return" width="1.8"/>
+    </row>
+    <row align="left">
+      <key name="Caribou_ShiftUp" toggle="level2"/>
+      <key name="semicolon"/>
+      <key name="q"/>
+      <key name="j"/>
+      <key name="k"/>
+      <key name="x"/>
+      <key name="b"/>
+      <key name="m"/>
+      <key name="w"/>
+      <key name="v"/>
+      <key name="z"/>
+      <key name="at" width="0.8"/>
+      <key name="bracketleft" width="0.6"/>
+      <key name="bracketright" width="0.6"/>
+    </row>
+    <row>
+      <key align="left" name="Caribou_Symbols" toggle="symbols1" width="2.0"/>
+      <key align="center" name="space" width="6.0" repeatable="yes"/>
+      <key align="right" name="Caribou_Prefs"/>
+    </row>
+  </level>
+  <level mode="latched" name="level2">
+    <row align="right">
+      <key name="quotedbl"/>
+      <key name="less"/>
+      <key name="greater"/>
+      <key name="P"/>
+      <key name="Y"/>
+      <key name="F"/>
+      <key name="G"/>
+      <key name="C">
+        <key name="C"/>
+        <key name="Ccedilla"/>
+      </key>
+      <key name="R"/>
+      <key name="L"/>
+      <key name="question" width="0.6">
+        <key name="question"/>
+        <key name="questiondown"/>
+      </key>
+      <key name="plus" width="0.6"/>
+      <key name="bar" width="0.6"/>
+      <key name="BackSpace" repeatable="yes"/>
+    </row>
+    <row align="right">
+      <key name="A">
+        <key name="A"/>
+        <key name="Agrave"/>
+        <key name="Aacute"/>
+        <key name="Acircumflex"/>
+        <key name="Adiaeresis"/>
+        <key name="Aring"/>
+        <key name="Atilde"/>
+        <key name="Ae"/>
+        <key name="Amacron"/>
+      </key>
+      <key name="O">
+        <key name="O"/>
+        <key name="Ograve"/>
+        <key name="Oacute"/>
+        <key name="Ocircumflex"/>
+        <key name="Odiaeresis"/>
+        <key name="Omacron"/>
+      </key>
+      <key name="E">
+        <key name="E"/>
+        <key name="Egrave"/>
+        <key name="Eacute"/>
+        <key name="Ecircumflex"/>
+        <key name="Ediaeresis"/>
+        <key name="Emacron"/>
+      </key>
+      <key name="U">
+        <key name="U"/>
+        <key name="Ugrave"/>
+        <key name="Uacute"/>
+        <key name="Ucircumflex"/>
+        <key name="Udiaeresis"/>
+        <key name="Umacron"/>
+      </key>
+      <key name="I">
+        <key name="I"/>
+        <key name="Igrave"/>
+        <key name="Iacute"/>
+        <key name="Icircumflex"/>
+        <key name="Idiaeresis"/>
+        <key name="Imacron"/>
+      </key>
+      <key name="D"/>
+      <key name="H"/>
+      <key name="T"/>
+      <key name="N"/>
+      <key name="S"/>
+      <key name="underscore"/>
+      <key name="Return" width="1.8"/>
+    </row>
+    <row align="right">
+      <key name="Caribou_ShiftDown" toggle="level1"/>
+      <key name="colon"/>
+      <key name="Q"/>
+      <key name="J"/>
+      <key name="K"/>
+      <key name="X"/>
+      <key name="B"/>
+      <key name="M"/>
+      <key name="W"/>
+      <key name="V"/>
+      <key name="Z"/>
+      <key name="at" width="0.8"/>
+      <key name="braceleft" width="0.6"/>
+      <key name="braceright" width="0.6"/>
+    </row>
+    <row>
+      <key align="left" name="Caribou_Symbols" toggle="symbols1" width="2.0"/>
+      <key align="center" name="space" width="6.0" repeatable="yes"/>
+      <key align="right" name="Caribou_Prefs"/>
+    </row>
+  </level>
+</external>

--- a/data/layouts/touch/us_dvorak.xml.in
+++ b/data/layouts/touch/us_dvorak.xml.in
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<layout xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="common/dvorak.xml#xpointer(//level[@name='level1'])"/>
+  <xi:include href="common/dvorak.xml#xpointer(//level[@name='level2'])"/>
+  <xi:include href="common/symbols.xml#xpointer(//level[@name='symbols1'])"/>
+  <xi:include href="common/symbols.xml#xpointer(//level[@name='symbols2'])"/>
+</layout>
+


### PR DESCRIPTION
i had a bit of difficulty getting things to align well, as caribou's layout configuration is rather limiting (seems the only way to adjust the location of keys is playing with the width and align options) but i made a dvorak touch layout. it's aligned as close to a physical keyboard as possible, and preserves the essential layout (including punctuation) of dvorak.

![lowercasedvorak](https://cloud.githubusercontent.com/assets/1589610/7268518/7266210a-e887-11e4-8148-59d9e51d9b61.png)
![uppercasedvorak](https://cloud.githubusercontent.com/assets/1589610/7268519/72675d2c-e887-11e4-9c3d-8a4d7aab4b12.png)
